### PR TITLE
Handle duplicate request telemetry keys

### DIFF
--- a/ApplicationInsightsRequestLogging/ApplicationInsightsRequestLogging/TelemetryWriter/TelemetryWriter.cs
+++ b/ApplicationInsightsRequestLogging/ApplicationInsightsRequestLogging/TelemetryWriter/TelemetryWriter.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.ApplicationInsights.DataContracts;
+﻿using System;
+using Microsoft.ApplicationInsights.DataContracts;
 using Microsoft.AspNetCore.Http;
 
 namespace Azureblue.ApplicationInsights.RequestLogging
@@ -7,7 +8,7 @@ namespace Azureblue.ApplicationInsights.RequestLogging
     {
         public void Write(HttpContext context, string key, string value)
         {
-            var requestTelemtry = context.Features.Get<RequestTelemetry>();
+            var requestTelemetry = context.Features.Get<RequestTelemetry>();
 
             // add to dictionary, creating an altered key name if already present
             requestTelemetry?.Properties.Add(

--- a/ApplicationInsightsRequestLogging/ApplicationInsightsRequestLogging/TelemetryWriter/TelemetryWriter.cs
+++ b/ApplicationInsightsRequestLogging/ApplicationInsightsRequestLogging/TelemetryWriter/TelemetryWriter.cs
@@ -8,7 +8,11 @@ namespace Azureblue.ApplicationInsights.RequestLogging
         public void Write(HttpContext context, string key, string value)
         {
             var requestTelemtry = context.Features.Get<RequestTelemetry>();
-            requestTelemtry?.Properties.Add(key, value);
+
+            // add to dictionary, creating an altered key name if already present
+            requestTelemetry?.Properties.Add(
+                !requestTelemetry.Properties.ContainsKey(key) ? key : $"{key}-dupe-{Guid.NewGuid().ToString()[..8]}",
+                value);
         }
     }
 }


### PR DESCRIPTION
I had an issue where Application Insights would log the Request and Response bodies twice on a request.  I added a dictionary check before logging and pseudo random suffix to indicate it in the logs.

![image](https://user-images.githubusercontent.com/4190823/193257051-5104e45d-9ce8-4937-892f-5d7ac228b54c.png)