### PR TITLE
#22: catch all downstream errors and log request body

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,5 +132,16 @@ public class BodyLoggerOptions
     ///     Controls storage of client IP addresses https://learn.microsoft.com/en-us/azure/azure-monitor/app/ip-collection?tabs=net
     /// </summary>
     public bool DisableIpMasking { get; set; } = false;
+    
+    /// <summary>
+    ///     Controls if the middleware should catch and rethrow exceptions to allow logging of request bodies
+    ///     even if downstream middlewares or handlers throw.
+    /// </summary>
+    /// <remarks>
+    ///     In some edge cases this might interfere with custom exception handlers or other middlewares catching exceptions.
+    ///     If you enable this feature, make sure that the body logger middleware is registered as early as possible
+    ///     on host creation.
+    /// </remarks>
+    public bool EnableBodyLoggingOnExceptions { get; set; } = false;
 }
 ```

--- a/src/ApplicationInsightsRequestLogging/BodyLoggerMiddleware.cs
+++ b/src/ApplicationInsightsRequestLogging/BodyLoggerMiddleware.cs
@@ -32,7 +32,18 @@ namespace Azureblue.ApplicationInsights.RequestLogging
             }
 
             // hand over to the next middleware and wait for the call to return
-            await next(context);
+            try
+            {
+                await next(context);
+            }
+            catch (Exception)
+            {
+                if (_options.HttpVerbs.Contains(context.Request.Method))
+                {
+                    _telemetryWriter.Write(context, _options.RequestBodyPropertyKey, _sensitiveDataFilter.RemoveSensitiveData(requestBody));
+                }
+                throw;
+            }
 
             if (_options.HttpVerbs.Contains(context.Request.Method))
             {

--- a/src/ApplicationInsightsRequestLogging/Options/BodyLoggerOptions.cs
+++ b/src/ApplicationInsightsRequestLogging/Options/BodyLoggerOptions.cs
@@ -56,6 +56,17 @@ namespace Azureblue.ApplicationInsights.RequestLogging
         /// </summary>
         public bool DisableIpMasking { get; set; } = false;
 
+        /// <summary>
+        ///     Controls if the middleware should catch and rethrow exceptions to allow logging of request bodies
+        ///     even if downstream middlewares or handlers throw.
+        /// </summary>
+        /// <remarks>
+        ///     In some edge cases this might interfere with custom exception handlers or other middlewares catching exceptions.
+        ///     If you enable this feature, make sure that the body logger middleware is registered as early as possible
+        ///     on host creation.
+        /// </remarks>
+        public bool EnableBodyLoggingOnExceptions { get; set; } = false;
+
         public List<string> PropertyNamesWithSensitiveData { get; set; } = new List<string>()
         {
             "password",

--- a/test/ManualTests/Controllers/TestController.cs
+++ b/test/ManualTests/Controllers/TestController.cs
@@ -17,12 +17,11 @@ namespace ManualTests.Controllers
         {
             return Ok(data);
         }
-    }
-}
 
-public class TestData
-{
-    public string Name { get; set; }
-    public string Blog { get; set; }
-    public string Topics { get; set; }
+        [HttpPost("throw")]
+        public ActionResult<string> ThrowException([FromBody] TestData data)
+        {
+            throw new InvalidOperationException("Test exception!");
+        }
+    }
 }

--- a/test/ManualTests/ManualTests.csproj
+++ b/test/ManualTests/ManualTests.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
-        <Nullable>enable</Nullable>
+        <Nullable>disable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
     </PropertyGroup>
 

--- a/test/ManualTests/Model/TestData.cs
+++ b/test/ManualTests/Model/TestData.cs
@@ -1,0 +1,8 @@
+public class TestData
+{
+    public string Name { get; set; }
+
+    public string Blog { get; set; }
+
+    public string Topics { get; set; }
+}

--- a/test/ManualTests/Program.cs
+++ b/test/ManualTests/Program.cs
@@ -12,14 +12,16 @@ ConfigureEndpoints(app, app.Services);
 
 app.Run();
 
-void ConfigureConfiguration(ConfigurationManager configuration) {}
+void ConfigureConfiguration(ConfigurationManager configuration) { }
 void ConfigureServices(IServiceCollection services)
 {
     services.AddApplicationInsightsTelemetry();
     services.AddAppInsightsHttpBodyLogging(o =>
     {
         o.HttpCodes.Add(StatusCodes.Status200OK);
+        o.HttpCodes.Add(StatusCodes.Status204NoContent);
         o.DisableIpMasking = true;
+        o.EnableBodyLoggingOnExceptions = true;
     });
     services.AddControllers();
     services.AddEndpointsApiExplorer();

--- a/test/ManualTests/appsettings.json
+++ b/test/ManualTests/appsettings.json
@@ -5,5 +5,8 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "ApplicationInsights": {
+    "ConnectionString": ""
+  }
 }


### PR DESCRIPTION
rudimentary implementation of the feature described in #22 .
I tried to touch as little code as possible. Especially in the tests this creates some code duplication. As the other tests are structured the same way I did not want to introduce major changes there.

If wanted I can refactor this, but this would require larger changes to be done in any meaningful way.

Other than indicated in #22 this feature would be enabled by default. During my testing the implementation as is does not interfere with other common middlewares that catch exceptions (e.g. DeveloperExceptionPage).