### PR TITLE
Added option to exclude specified content types

### DIFF
--- a/src/ApplicationInsightsRequestLogging/Options/BodyLoggerOptions.cs
+++ b/src/ApplicationInsightsRequestLogging/Options/BodyLoggerOptions.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Http;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Azureblue.ApplicationInsights.RequestLogging
 {
@@ -25,6 +26,11 @@ namespace Azureblue.ApplicationInsights.RequestLogging
             HttpMethods.Put,
             HttpMethods.Patch
         };
+
+        /// <summary>
+        ///     Content types that will be excluded from logging
+        /// </summary>
+        public List<string> ExcludedContentTypes { get; set; } = new List<string>();        
 
         /// <summary>
         ///     Which property key should be used
@@ -84,5 +90,7 @@ namespace Azureblue.ApplicationInsights.RequestLogging
         {
             @"(?:4[0-9]{12}(?:[0-9]{3})?|[25][1-7][0-9]{14}|6(?:011|5[0-9][0-9])[0-9]{12}|3[47][0-9]{13}|3(?:0[0-5]|[68][0-9])[0-9]{11}|(?:2131|1800|35\d{3})\d{11})" // credit cards from https://stackoverflow.com/questions/9315647/regex-credit-card-number-tests
         };
+
+        internal bool IsExcludedContentType(string contentType) => ExcludedContentTypes.Any(ct => contentType.StartsWith(ct, System.StringComparison.InvariantCultureIgnoreCase));
     }
 }

--- a/test/ApplicationInsightsRequestLoggingTests/BodyLoggerMiddlewareTests.cs
+++ b/test/ApplicationInsightsRequestLoggingTests/BodyLoggerMiddlewareTests.cs
@@ -378,5 +378,40 @@ namespace ApplicationInsightsRequestLoggingTests
             requestItem.Should().NotBeNull();
             requestItem?.Properties["ClientIp"].Should().Be("127.168.1.32");
         }
-    }
+
+		[Fact]
+		public async void BodyLoggerMiddleware_should_not_log_request_body_if_excluded_content_type() {
+			// Arrange
+			var telemetryWriter = new Mock<ITelemetryWriter>();
+
+			using var host = await new HostBuilder()
+				.ConfigureWebHost(webBuilder => {
+					webBuilder
+						.UseTestServer()
+						.ConfigureServices(services => {
+							services.AddOptions<BodyLoggerOptions>().Configure(options => {
+                                options.ExcludedContentTypes = new List<string> { "multipart/form-data" };
+							});
+							services.AddTransient<IBodyReader, BodyReader>();
+							services.AddTransient<ISensitiveDataFilter, SensitiveDataFilter>();
+							services.AddSingleton(telemetryWriter.Object);
+							services.AddTransient<BodyLoggerMiddleware>();
+						})
+						.Configure(app => {
+							app.UseMiddleware<BodyLoggerMiddleware>();
+						});
+				})
+				.StartAsync();
+
+			// Act
+			try {
+				await host.GetTestClient().PostAsync("/", new StringContent("Hello from client", encoding: null, mediaType: "multipart/form-data"));
+			} catch(Exception) {
+				//ignore errors thrown by test client
+			}
+
+			// Assert
+			telemetryWriter.VerifyNoOtherCalls();
+		}
+	}
 }


### PR DESCRIPTION
For our use case we require that EnableBuffering is not called for certain large file uploads (to stream the file to storage).

However, I can't find any way to exclude this in this library, without excluding an entire verb. This PR adds the option to exclude specified content types from logging (in our case "multipart/form-data").

Another possible exclusion criteria could be to stop logging if content length > options.MaxBytes.